### PR TITLE
Add missing properties to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,3 +5,5 @@ maintainer=Martin Sosic <martin.sosic@gmail.com>
 sentence=Library for HC-SR04 ultrasonic distance sensor.
 paragraph=You can measure distance in centimeters.
 category=Sensors
+url=https://github.com/Martinsos/arduino-lib-hc-sr04
+architectures=*


### PR DESCRIPTION
url property is required to install the library via the Arduino IDE's **Sketch > Include Library > Add .ZIP library**.

I believe the missing property is also the cause of the library not being available from the Arduino IDE Library Manager (see: https://github.com/arduino/Arduino/issues/7174#issuecomment-363014319). If so, you would need to create a new release after making this change before it will be in Library Manager.

cc: @cmaglie