### PR TITLE
Allow for temperature compensated output

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Sensor is initialized by creating instance of class UltraSonicDistanceSensor and
 
 Then, to measure the distance, you just call `measureDistanceCm()`, which will return distance in centimeters (double). If distance is larger than 400cm, it will return negative value.
 
+The calculation assumes a temperature of around 20°C. For improved accuracy you may also provide a temperature yourself, either an average for your location or directly measured from another sensor. The call for a temperature of 3.5°C would as such look like this: `measureDistanceCm(3.5)`.
 
 ## Example
 

--- a/examples/temperature/temperature.ino
+++ b/examples/temperature/temperature.ino
@@ -1,0 +1,28 @@
+#include <HCSR04.h>
+
+//This example uses a DS18B20 1Wire Temperature sensor
+//Of course you can use something else like DHT22, LM35 or whatever you have lying around.
+#include <OneWire.h>
+#include <DallasTemperature.h>
+
+UltraSonicDistanceSensor distanceSensor(13, 12);  // Initialize sensor that uses digital pins 13 and 12.
+OneWire oneWire(11);
+DallasTemperature sens_temperature(&oneWire);
+
+void setup () {
+    Serial.begin(9600);  // We initialize serial connection so that we could print values from sensor.
+}
+
+void loop () {
+    // Every 1 second, do a measurement using the sensor and print the distance in centimeters.
+    sens_temperature.requestTemperatures();
+    float temperature = sens_temperature.getTempCByIndex(0);
+    double distance = distanceSensor.measureDistanceCm(temperature);
+
+    Serial.print(F("Temperature: "));
+    Serial.print(temperature);
+    Serial.print(F("°C - Distance: "));
+    Serial.print(distance);
+    Serial.println(F("cm"));
+    delay(1000);
+}

--- a/src/HCSR04.cpp
+++ b/src/HCSR04.cpp
@@ -15,6 +15,11 @@ UltraSonicDistanceSensor::UltraSonicDistanceSensor(
 }
 
 double UltraSonicDistanceSensor::measureDistanceCm() {
+    //Using the approximate formula 19.307°C results in roughly 343m/s which is the commonly used value for air.
+    return measureDistanceCm(19.307);
+}
+
+double UltraSonicDistanceSensor::measureDistanceCm(float temperature) {
     // Make sure that trigger pin is LOW.
     digitalWrite(triggerPin, LOW);
     delayMicroseconds(2);
@@ -24,7 +29,9 @@ double UltraSonicDistanceSensor::measureDistanceCm() {
     digitalWrite(triggerPin, LOW);
     // Measure the length of echo signal, which is equal to the time needed for sound to go there and back.
     unsigned long durationMicroSec = pulseIn(echoPin, HIGH);
-    double distanceCm = durationMicroSec / 2.0 * 0.0343;
+
+    double speedOfSoundInCmPerMs = 0.03313 + 0.0000606 * temperature // Cair ≈ (331.3 + 0.606 ⋅ ϑ) m/s
+    double distanceCm = durationMicroSec / 2.0 * speedOfSoundInCmPerMs;
     if (distanceCm == 0 || distanceCm > 400) {
         return -1.0 ;
     } else {

--- a/src/HCSR04.h
+++ b/src/HCSR04.h
@@ -22,6 +22,14 @@ class UltraSonicDistanceSensor {
      * @returns Distance in centimeters, or negative value if distance is greater than 400cm.
      */
     double measureDistanceCm();
+
+    /**
+     * Measures distance by sending ultrasonic waves and measuring time it takes them
+     * to return.
+     * @param temperature  Temperature in degrees celsius
+     * @returns Distance in centimeters, or negative value if distance is greater than 400cm.
+     */
+    double measureDistanceCm(float temperature);
  private:
     int triggerPin, echoPin;
 };


### PR DESCRIPTION
The current code uses 343m/s as a constant value for speed of sound. This assumes a temperature of 20°C. When measuring in significantly different temperatures, like 0°C, this will introduce an small but noticeable error.
This pull request allows to optionally compensate the output for temperature as per the [simplified derivate of the first two terms of the Taylor expansion](https://en.wikipedia.org/wiki/Speed_of_sound#Practical_formula_for_dry_air) (`Cair ≈ (331.3 + 0.606 ⋅ ϑ) m/s`).
When no temperature is given a hardcoded value resulting in about the same output as the current code is used.